### PR TITLE
Breaking change when upgrading durable tasks

### DIFF
--- a/FunctionApp5/FunctionApp5.csproj
+++ b/FunctionApp5/FunctionApp5.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
This change causes function to die in Azure and on local. 

![image](https://user-images.githubusercontent.com/8628769/180420655-c6b5bccd-59b5-4456-83ca-00ef3a95ddee.png)

You can bypass this by adding "Storage" configuration into app settings, but I didn't find any documentation related to this.